### PR TITLE
Publish to GHCR OCI repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Github Action to bump `chartVersion` and `appVersion` in Mittwald Helm Charts.
 
 Optionally, the new chart version can be published to [helm.mittwald.de](helm.mittwald.de).
+Additionally, the chart is published to GitHub's Container registry.
 
 The chart version is automatically determined using the `GITHUB_REF` environment variable: `TAG="${GITHUB_REF##*/}"`.
 

--- a/bump-app-version.sh
+++ b/bump-app-version.sh
@@ -84,7 +84,8 @@ if [[ "${MODE}" == "publish" ]]; then
     ## upload chart
     helm repo add mittwald https://helm.mittwald.de --force-update
     helm cm-push "${CHART_PATH}" mittwald
-
+    echo "${GITHUB_TOKEN}}" | docker login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
+    helm push "${CHART_PATH}" "oci://ghcr.io/${GITHUB_REPOSITORY}"
 fi
 
 exit 0


### PR DESCRIPTION
This adds publishing to the ghcr OCI repository

Fixing https://github.com/mittwald/kubernetes-replicator/issues/373 